### PR TITLE
Front: Home View: Fix Overlap when empty card grid

### DIFF
--- a/front/views/HomeView.tsx
+++ b/front/views/HomeView.tsx
@@ -68,13 +68,13 @@ const HomeView = () => {
 					}
 				/>
 				<Stack direction={{ base: 'column', lg: 'row' }}>
-					<Box flex={{ md: 1 }}>
+					<Box flex={{ lg: 1 }}>
 						<Heading><Translate translationKey='mySkillsToImprove'/></Heading>
 						<Box padding={5}>
 							<CompetenciesTable {...skillsQuery.data}/>
 						</Box>
 					</Box>
-					<Box flex={{ md: 1 }}>
+					<Box flex={{ lg: 1 }}>
 						<SongCardGrid
 							heading={<Translate translationKey='recentlyPlayed'/>}
 							songs={songHistory


### PR DESCRIPTION
Fix overlap on Home View that occured when:

- Empty Card Grid
- md breakpoint

Before:
![before](https://user-images.githubusercontent.com/60505370/235146100-dd447c10-b375-4793-8d77-64add08a84b3.png)

After:
![after](https://user-images.githubusercontent.com/60505370/235146094-1b159e0d-db3a-4436-9344-6b2c8741c426.png)

The problem was the use of the wrong breakpoint for flex 