### PR TITLE
Front: add Button to Download APK From Web

### DIFF
--- a/front/components/APKDownloadButton.tsx
+++ b/front/components/APKDownloadButton.tsx
@@ -1,0 +1,20 @@
+import { ArrowCircleDown2 } from 'iconsax-react-native';
+import ButtonBase from './UI/ButtonBase';
+import { translate } from '../i18n/i18n';
+import { Linking } from 'react-native';
+
+const APKDownloadButton = () => {
+	return (
+		<ButtonBase
+			style={{}}
+			icon={ArrowCircleDown2}
+			type={'filled'}
+			title={translate('downloadAPK')}
+			onPress={() =>
+				Linking.openURL('https://github.com/Chroma-Case/Chromacase/releases/download/v0.8.4/android-build.apk')
+			}
+		/>
+	);
+};
+
+export default APKDownloadButton;

--- a/front/components/APKDownloadButton.tsx
+++ b/front/components/APKDownloadButton.tsx
@@ -2,18 +2,36 @@ import { ArrowCircleDown2 } from 'iconsax-react-native';
 import ButtonBase from './UI/ButtonBase';
 import { translate } from '../i18n/i18n';
 import { Linking } from 'react-native';
+import { useState } from 'react';
+import PopupCC from './UI/PopupCC';
 
 const APKDownloadButton = () => {
+	const [isOpen, setIsOpen] = useState(false);
+	// 
 	return (
-		<ButtonBase
-			style={{}}
-			icon={ArrowCircleDown2}
-			type={'filled'}
-			title={translate('downloadAPK')}
-			onPress={() =>
-				Linking.openURL('https://github.com/Chroma-Case/Chromacase/releases/download/v0.8.4/android-build.apk')
-			}
-		/>
+		<>
+			<ButtonBase
+				style={{}}
+				icon={ArrowCircleDown2}
+				type={'filled'}
+				title={translate('downloadAPK')}
+				onPress={() => setIsOpen(true)}
+			/>
+			<PopupCC
+				title={translate('downloadAPK')}
+				description={translate('downloadAPKInstructions')}
+				isVisible={isOpen}
+				setIsVisible={setIsOpen}
+			>
+				<ButtonBase
+					style={{}}
+					icon={ArrowCircleDown2}
+					type={'filled'}
+					title={translate('downloadAPK')}
+					onPress={() => Linking.openURL('https://github.com/Chroma-Case/Chromacase/releases')}
+				/>	
+			</PopupCC>
+		</>
 	);
 };
 

--- a/front/components/APKDownloadButton.tsx
+++ b/front/components/APKDownloadButton.tsx
@@ -7,7 +7,7 @@ import PopupCC from './UI/PopupCC';
 
 const APKDownloadButton = () => {
 	const [isOpen, setIsOpen] = useState(false);
-	// 
+
 	return (
 		<>
 			<ButtonBase
@@ -28,8 +28,10 @@ const APKDownloadButton = () => {
 					icon={ArrowCircleDown2}
 					type={'filled'}
 					title={translate('downloadAPK')}
-					onPress={() => Linking.openURL('https://github.com/Chroma-Case/Chromacase/releases')}
-				/>	
+					onPress={() =>
+						Linking.openURL('https://github.com/Chroma-Case/Chromacase/releases')
+					}
+				/>
 			</PopupCC>
 		</>
 	);

--- a/front/components/UI/ScaffoldAuth.tsx
+++ b/front/components/UI/ScaffoldAuth.tsx
@@ -165,7 +165,7 @@ const ScaffoldAuth: FunctionComponent<ScaffoldAuthProps> = ({
 								<Text>{link.label}</Text>
 								<LinkBase text={link.text} onPress={link.onPress} />
 							</Wrap>
-							{ Platform.OS === "web" && <APKDownloadButton/> }
+							{Platform.OS === 'web' && <APKDownloadButton />}
 						</Stack>
 					</View>
 				</ScrollView>

--- a/front/components/UI/ScaffoldAuth.tsx
+++ b/front/components/UI/ScaffoldAuth.tsx
@@ -1,7 +1,7 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import { Stack, View, Text, Wrap, Image, Row, Column, ScrollView, useToast } from 'native-base';
 import { FunctionComponent } from 'react';
-import { Linking, useWindowDimensions } from 'react-native';
+import { Linking, Platform, useWindowDimensions } from 'react-native';
 import ButtonBase from './ButtonBase';
 import { translate } from '../../i18n/i18n';
 import API, { APIError } from '../../API';
@@ -11,6 +11,7 @@ import { useDispatch } from '../../state/Store';
 import { setAccessToken } from '../../state/UserSlice';
 import useColorScheme from '../../hooks/colorScheme';
 import { useAssets } from 'expo-asset';
+import APKDownloadButton from '../APKDownloadButton';
 
 const handleGuestLogin = async (apiSetter: (accessToken: string) => void): Promise<string> => {
 	const apiAccess = await API.createAndGetGuestAccount();
@@ -81,7 +82,7 @@ const ScaffoldAuth: FunctionComponent<ScaffoldAuthProps> = ({
 						)}
 					</Row>
 					<ButtonBase
-						title="guest mode"
+						title={translate('guestMode')}
 						onPress={async () => {
 							try {
 								handleGuestLogin((accessToken: string) => {
@@ -164,6 +165,7 @@ const ScaffoldAuth: FunctionComponent<ScaffoldAuthProps> = ({
 								<Text>{link.label}</Text>
 								<LinkBase text={link.text} onPress={link.onPress} />
 							</Wrap>
+							{ Platform.OS === "web" && <APKDownloadButton/> }
 						</Stack>
 					</View>
 				</ScrollView>

--- a/front/i18n/Translations.ts
+++ b/front/i18n/Translations.ts
@@ -1,7 +1,7 @@
 export const en = {
 	error: 'Error',
-	guestMode: "Guest Mode",
-	downloadAPK: "Download Android App",
+	guestMode: 'Guest Mode',
+	downloadAPK: 'Download Android App',
 	goBackHome: 'Go Back Home',
 	anErrorOccured: 'An Error Occured',
 	welcome: 'Welcome',
@@ -317,13 +317,14 @@ export const en = {
 	forgotPassword: 'I forgot my password',
 	updateProfile: 'Update Profile',
 	accountCreatedOn: 'Account Created on',
-	downloadAPKInstructions: 'Go to the latest release, unfold the \'Assets\' section, and click \'android-build.apk\'.'
+	downloadAPKInstructions:
+		"Go to the latest release, unfold the 'Assets' section, and click 'android-build.apk'.",
 };
 
 export const fr: typeof en = {
 	error: 'Erreur',
 	downloadAPK: "Télécharger l'App Android",
-	guestMode: "Mode Invité",
+	guestMode: 'Mode Invité',
 	goBackHome: "Retourner à l'accueil",
 	anErrorOccured: 'Une erreur est survenue',
 	welcome: 'Bienvenue',
@@ -639,13 +640,14 @@ export const fr: typeof en = {
 	forgotPassword: "J'ai oublié mon mot de passe",
 	updateProfile: 'Changer le Profile',
 	accountCreatedOn: 'Compte créé le',
-	downloadAPKInstructions: 'Descargue \'android-build.apk\' en la sección \'Assets\' de la última versión.'
+	downloadAPKInstructions:
+		"Descargue 'android-build.apk' en la sección 'Assets' de la última versión.",
 };
 
 export const sp: typeof en = {
 	error: 'Error',
-	downloadAPK: "Descarga la Aplicación de Android",
-	guestMode: "Modo Invitado",
+	downloadAPK: 'Descarga la Aplicación de Android',
+	guestMode: 'Modo Invitado',
 	anErrorOccured: 'ocurrió un error',
 	goBackHome: 'regresar a casa',
 	welcomeMessage: 'Benvenido',
@@ -968,5 +970,6 @@ export const sp: typeof en = {
 	forgotPassword: 'Olvidé mi contraseña',
 	updateProfile: 'Cambiar el perfil',
 	accountCreatedOn: 'Cuenta creada el',
-	downloadAPKInstructions: 'Télécharger \'android-build.apk\' dans la section \'Assets\' de la dernière release'
+	downloadAPKInstructions:
+		"Télécharger 'android-build.apk' dans la section 'Assets' de la dernière release",
 };

--- a/front/i18n/Translations.ts
+++ b/front/i18n/Translations.ts
@@ -1,5 +1,7 @@
 export const en = {
 	error: 'Error',
+	guestMode: "Guest Mode",
+	downloadAPK: "Download Android App",
 	goBackHome: 'Go Back Home',
 	anErrorOccured: 'An Error Occured',
 	welcome: 'Welcome',
@@ -319,6 +321,8 @@ export const en = {
 
 export const fr: typeof en = {
 	error: 'Erreur',
+	downloadAPK: "Télécharger l'App Android",
+	guestMode: "Mode Invité",
 	goBackHome: "Retourner à l'accueil",
 	anErrorOccured: 'Une erreur est survenue',
 	welcome: 'Bienvenue',
@@ -638,6 +642,8 @@ export const fr: typeof en = {
 
 export const sp: typeof en = {
 	error: 'Error',
+	downloadAPK: "Descarga la Aplicación de Android",
+	guestMode: "Modo Invitado",
 	anErrorOccured: 'ocurrió un error',
 	goBackHome: 'regresar a casa',
 	welcomeMessage: 'Benvenido',

--- a/front/i18n/Translations.ts
+++ b/front/i18n/Translations.ts
@@ -317,6 +317,7 @@ export const en = {
 	forgotPassword: 'I forgot my password',
 	updateProfile: 'Update Profile',
 	accountCreatedOn: 'Account Created on',
+	downloadAPKInstructions: 'Go to the latest release, unfold the \'Assets\' section, and click \'android-build.apk\'.'
 };
 
 export const fr: typeof en = {
@@ -638,6 +639,7 @@ export const fr: typeof en = {
 	forgotPassword: "J'ai oublié mon mot de passe",
 	updateProfile: 'Changer le Profile',
 	accountCreatedOn: 'Compte créé le',
+	downloadAPKInstructions: 'Descargue \'android-build.apk\' en la sección \'Assets\' de la última versión.'
 };
 
 export const sp: typeof en = {
@@ -966,4 +968,5 @@ export const sp: typeof en = {
 	forgotPassword: 'Olvidé mi contraseña',
 	updateProfile: 'Cambiar el perfil',
 	accountCreatedOn: 'Cuenta creada el',
+	downloadAPKInstructions: 'Télécharger \'android-build.apk\' dans la section \'Assets\' de la dernière release'
 };

--- a/front/views/settings/SettingsProfile.tsx
+++ b/front/views/settings/SettingsProfile.tsx
@@ -163,7 +163,7 @@ const ProfileSettings = () => {
 						},
 					]}
 				/>
-				{ Platform.OS === "web" && <APKDownloadButton/> }
+				{Platform.OS === 'web' && <APKDownloadButton />}
 				<LogoutButtonCC isGuest={user.isGuest} buttonType={'filled'} />
 			</Column>
 		</ScrollView>

--- a/front/views/settings/SettingsProfile.tsx
+++ b/front/views/settings/SettingsProfile.tsx
@@ -10,7 +10,8 @@ import { Google, PasswordCheck, SmsEdit, UserSquare, Verify } from 'iconsax-reac
 import ChangeEmailForm from '../../components/forms/changeEmailForm';
 import ChangePasswordForm from '../../components/forms/changePasswordForm';
 import LogoutButtonCC from '../../components/UI/LogoutButtonCC';
-import { ScrollView } from 'react-native';
+import { Platform, ScrollView } from 'react-native';
+import APKDownloadButton from '../../components/APKDownloadButton';
 
 const handleChangeEmail = async (newEmail: string): Promise<string> => {
 	await API.updateUserEmail(newEmail);
@@ -162,6 +163,7 @@ const ProfileSettings = () => {
 						},
 					]}
 				/>
+				{ Platform.OS === "web" && <APKDownloadButton/> }
 				<LogoutButtonCC isGuest={user.isGuest} buttonType={'filled'} />
 			</Column>
 		</ScrollView>


### PR DESCRIPTION
TODO:
Currently, We redirect to GitHub's Release/Tag Page. Shouldn't we directly download the APK?

<img width="499" alt="Screenshot 2023-12-25 at 18 57 25" src="https://github.com/Chroma-Case/Chromacase/assets/60505370/c99753c2-73d3-4303-99a6-60476ec4345a">
<img width="499" alt="Screenshot 2023-12-25 at 18 57 38" src="https://github.com/Chroma-Case/Chromacase/assets/60505370/ba2768d2-ff99-487b-829b-87eaa0f4b2f6">
